### PR TITLE
Fixing some caching errors

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-/* global require, describe, it, before */
+/* global require, describe, it */
 'use strict';
 
 var Hapi = require('hapi');


### PR DESCRIPTION
Mostly from https://github.com/hotosm/oam-catalog/commit/3a70cae7af92e032ed7c6b005041c0fda17a0686

Also fixes an issue where calls to a exclude route after calling an included route would still pass back the meta fields. The tests look like they should already be catching this, but they're passing. It may have to do with using both hapi-meta and hapi-paginate together?
